### PR TITLE
Add Pusher class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.lock
+.phpunit.result.cache
 /vendor
 .idea

--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,12 @@
     }
   },
   "minimum-stability": "dev",
-  "prefer-stable": true
+  "prefer-stable": true,
+  "scripts": {
+    "tests": "./vendor/bin/phpunit tests/",
+    "coverage": "./vendor/bin/phpunit --whitelist tests/ --coverage-html tests/coverage/",
+    "check": [
+      "@tests"
+    ]
+  }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnError="false" stopOnFailure="false" verbose="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage includeUncoveredFiles="false">
+    <include>
+      <directory suffix=".php">./src/</directory>
+    </include>
+    <report>
+      <clover outputFile="./coverage/coverage-clover.xml"/>
+      <html outputDirectory="./coverage/" lowUpperBound="35" highLowerBound="70"/>
+      <text outputFile="php://stdout" showUncoveredFiles="true"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Laravel Test Suite">
+      <directory suffix="Test.php">./tests/</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <php>
+    <env name="CACHE_DRIVER" value="redis"/>
+  </php>
+</phpunit>

--- a/src/Exceptions/PusherException.php
+++ b/src/Exceptions/PusherException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Arquivei\Events\Sender\Exceptions;
+
+use Throwable;
+
+class PusherException extends \Exception
+{
+
+    /**
+     * PusherException constructor.
+     */
+    public function __construct(Throwable $previous)
+    {
+        parent::__construct('Failed to push event', 0, $previous);
+    }
+}

--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Arquivei\Events\Sender;
+
+use Arquivei\Events\Sender\Exceptions\EmptyExportersException;
+use Arquivei\Events\Sender\Exceptions\PusherException;
+use Arquivei\Events\Sender\Exporters\ExporterInterface;
+use Arquivei\Events\Sender\Schemas\BaseSchema;
+use Throwable;
+
+class Pusher
+{
+    private $exporter;
+
+    /**
+     * Pusher constructor.
+     * @param ExporterInterface $exporter
+     */
+    public function __construct(ExporterInterface $exporter)
+    {
+        $this->exporter = $exporter;
+    }
+
+    /**
+     * @param BaseSchema $schema
+     * @param string $stream
+     * @param string|null $key
+     * @throws EmptyExportersException
+     * @throws PusherException
+     */
+    public function push(BaseSchema $schema, string $stream, string $key = null): void
+    {
+        if (empty($this->exporter)) {
+            throw new EmptyExportersException();
+        }
+
+        try {
+            $this->exporter->push($schema, $stream, $key);
+        } catch (Throwable $exception) {
+            throw new PusherException($exception);
+        }
+    }
+}

--- a/tests/PusherTest.php
+++ b/tests/PusherTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Arquivei\Events\Sender\Tests;
+
+use Arquivei\Events\Sender\Exceptions\FailedSenderToKafkaException;
+use Arquivei\Events\Sender\Exceptions\PusherException;
+use Arquivei\Events\Sender\Exporters\ExporterInterface;
+use Arquivei\Events\Sender\Factories\LatestSchemaFactory;
+use Arquivei\Events\Sender\Pusher;
+use PHPUnit\Framework\TestCase;
+
+class PusherTest extends TestCase
+{
+    private $schema;
+    private $exporter;
+
+    protected function setUp(): void
+    {
+        $latestSchemaFactory = new LatestSchemaFactory();
+        $data = ['id' => 'test'];
+        $this->schema = $latestSchemaFactory->createFromParameters('source', 'type', 1, $data);
+        $this->exporter = $this->createMock(ExporterInterface::class);
+    }
+
+    public function testPushEvent(): void
+    {
+        $this->exporter->expects(self::once())->method('push');
+
+        $pusher = new Pusher($this->exporter);
+        $pusher->push($this->schema,'topic');
+    }
+
+    public function testExporterThrowException(): void
+    {
+        $this->exporter->expects(self::once())
+            ->method('push')
+            ->willThrowException(new FailedSenderToKafkaException());
+
+        $this->expectException(PusherException::class);
+
+        $pusher = new Pusher($this->exporter);
+        $pusher->push($this->schema,'topic');
+    }
+}


### PR DESCRIPTION
- Push events to a single exporter
- Throw exception if any error happens

Today our Sender() try to send an event to many exporters and it ignores
exception if happens.