### PR TITLE
Fix exporters tests namespaces

### DIFF
--- a/tests/Exporters/FileTest.php
+++ b/tests/Exporters/FileTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Arquivei\Events\Sender\Tests;
+namespace Arquivei\Events\Sender\Tests\Exporters;
 
 use PHPUnit\Framework\TestCase;
 use Arquivei\Events\Sender\Exporters\File;

--- a/tests/Exporters/KafkaTest.php
+++ b/tests/Exporters/KafkaTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Arquivei\Events\Sender\Tests;
+namespace Arquivei\Events\Sender\Tests\Exporters;
 
 use PHPUnit\Framework\TestCase;
 use Arquivei\Events\Sender\Exporters\Kafka;

--- a/tests/Exporters/KinesisTest.php
+++ b/tests/Exporters/KinesisTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Arquivei\Events\Sender\Tests;
+namespace Arquivei\Events\Sender\Tests\Exporters;
 
 use PHPUnit\Framework\TestCase;
 use Arquivei\Events\Sender\Exporters\Kinesis;


### PR DESCRIPTION
Changed exporters (Kafka, File and Kinesis) tests namespaces to follow
PSR-4 standard.