### PR TITLE
Add new Kafka Producer config property

### DIFF
--- a/src/Exporters/Kafka.php
+++ b/src/Exporters/Kafka.php
@@ -46,6 +46,10 @@ class Kafka implements ExporterInterface
         $conf->set('sasl.username', $config['sasl_username']);
         $conf->set('sasl.password', $config['sasl_password']);
 
+        if(isset($config['message_max_bytes']) && $config['message_max_bytes'] !== '') {
+            $conf->set('message.max.bytes', $config['message_max_bytes']);
+        }
+        
         return $conf;
     }
 


### PR DESCRIPTION
This adds a new possibility when setting up a Kafka exporter: specifying a value for the producer property `message.max.bytes`. This will allow us to send larger messages to Kafka.

The value must be an integer representing the maximum size of the message in bytes. To specify a value, we just need to add a new key `"message_max_bytes"` to the config array passed to the constructor of the class `Arquivei\Events\Sender\Exporters\Kafka`.