### PR TITLE
feat: Adiciona a possibilidade de injetar `ssl_ca_location` no exporter kafka

### DIFF
--- a/src/Exporters/Kafka.php
+++ b/src/Exporters/Kafka.php
@@ -46,10 +46,14 @@ class Kafka implements ExporterInterface
         $conf->set('sasl.username', $config['sasl_username']);
         $conf->set('sasl.password', $config['sasl_password']);
 
+        if (isset($config['ssl_ca_location']) && $config['ssl_ca_location'] !== '') {
+            $conf->set('ssl.ca.location', $config['ssl_ca_location']);
+        }
+
         if(isset($config['message_max_bytes']) && $config['message_max_bytes'] !== '') {
             $conf->set('message.max.bytes', $config['message_max_bytes']);
         }
-        
+
         return $conf;
     }
 

--- a/src/Exporters/Kafka.php
+++ b/src/Exporters/Kafka.php
@@ -50,7 +50,7 @@ class Kafka implements ExporterInterface
             $conf->set('ssl.ca.location', $config['ssl_ca_location']);
         }
 
-        if(isset($config['message_max_bytes']) && $config['message_max_bytes'] !== '') {
+        if (isset($config['message_max_bytes']) && $config['message_max_bytes'] !== '') {
             $conf->set('message.max.bytes', $config['message_max_bytes']);
         }
         

--- a/src/Exporters/Kafka.php
+++ b/src/Exporters/Kafka.php
@@ -46,14 +46,14 @@ class Kafka implements ExporterInterface
         $conf->set('sasl.username', $config['sasl_username']);
         $conf->set('sasl.password', $config['sasl_password']);
 
-        if (!empty($config['ssl_ca_location'])) {
+        if (isset($config['ssl_ca_location']) && $config['ssl_ca_location'] !== '') {
             $conf->set('ssl.ca.location', $config['ssl_ca_location']);
         }
 
         if(isset($config['message_max_bytes']) && $config['message_max_bytes'] !== '') {
             $conf->set('message.max.bytes', $config['message_max_bytes']);
         }
-
+        
         return $conf;
     }
 

--- a/src/Exporters/Kafka.php
+++ b/src/Exporters/Kafka.php
@@ -46,7 +46,7 @@ class Kafka implements ExporterInterface
         $conf->set('sasl.username', $config['sasl_username']);
         $conf->set('sasl.password', $config['sasl_password']);
 
-        if (isset($config['ssl_ca_location']) && $config['ssl_ca_location'] !== '') {
+        if (!empty($config['ssl_ca_location'])) {
             $conf->set('ssl.ca.location', $config['ssl_ca_location']);
         }
 


### PR DESCRIPTION
Nesse PR estou adicionando a possibilidade de habilitar a comunicação por SSL com o broker Kafka, para isso estou habilitando a possibilidade de atribuir o caminho do certificado para a prop `ssl.ca.location`.
